### PR TITLE
Automatically hide servers item in navbar if the api does not support it

### DIFF
--- a/src/app/components/navBar.tsx
+++ b/src/app/components/navBar.tsx
@@ -1,24 +1,31 @@
-"use client";
-import Link from "next/link";
-import React from "react";
-import Image from "next/image";
-import { Button } from "@/app/components/ui/button";
-import { Moon, Sun, Monitor } from "lucide-react";
-import { useTheme } from "next-themes";
+'use client';
+import Link from 'next/link';
+import React from 'react';
+import Image from 'next/image';
+import { Button } from '@/app/components/ui/button';
+import { Moon, Sun, Monitor } from 'lucide-react';
+import { useTheme } from 'next-themes';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "@/app/components/ui/dropdown-menu";
+} from '@/app/components/ui/dropdown-menu';
 import {
   NavigationMenu,
   NavigationMenuItem,
   NavigationMenuList,
-} from "@/app/components/ui/navigation-menu";
+} from '@/app/components/ui/navigation-menu';
+import CheckServersEndpoint from '@/app/utils/checkServersAPI';
 
 const NavBar: React.FC = () => {
   const { setTheme } = useTheme();
+  // create useEffect to check if endpoint is live
+  const [endpointIsLive, setEndpointIsLive] = React.useState(false);
+  React.useEffect(() => {
+    CheckServersEndpoint().then((res) => setEndpointIsLive(res));
+  }, []);
+
   return (
     <nav className="flex-no-wrap relative flex w-full items-center justify-between">
       <NavigationMenu className="p-4">
@@ -52,11 +59,14 @@ const NavBar: React.FC = () => {
             </Button>
           </NavigationMenuItem>
 
-          <NavigationMenuItem>
-            <Button className="px-3">
-              <Link href="/servers">Our Servers</Link>
-            </Button>
-          </NavigationMenuItem>
+          {/* Show Servers if API is up */}
+          {endpointIsLive && (
+            <NavigationMenuItem>
+              <Button className="px-3">
+                <Link href="/servers">Servers</Link>
+              </Button>
+            </NavigationMenuItem>
+          )}
         </NavigationMenuList>
       </NavigationMenu>
 
@@ -70,13 +80,13 @@ const NavBar: React.FC = () => {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={() => setTheme("light")}>
+            <DropdownMenuItem onClick={() => setTheme('light')}>
               <Sun /> &nbsp; Light
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => setTheme("dark")}>
+            <DropdownMenuItem onClick={() => setTheme('dark')}>
               <Moon /> &nbsp; Dark
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => setTheme("system")}>
+            <DropdownMenuItem onClick={() => setTheme('system')}>
               <Monitor /> &nbsp; System
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/src/app/utils/checkServersAPI.ts
+++ b/src/app/utils/checkServersAPI.ts
@@ -1,0 +1,11 @@
+'use server';
+export default async function CheckServersEndpoint(): Promise<boolean> {
+  const response = await fetch('https://dcssbapi.twothreexray.com/servers', {
+    next: { revalidate: 120 },
+  });
+  if (response.ok) {
+    return true;
+  } else {
+    return false;
+  }
+}


### PR DESCRIPTION
Potential issues: If the api is momentarily not available, it could hide the page.